### PR TITLE
Created setUpStreamFromSprint1ToOriginMain.Java

### DIFF
--- a/src/main/java/com/example/demo/setUpStreamFromSprint1ToOriginMain.java
+++ b/src/main/java/com/example/demo/setUpStreamFromSprint1ToOriginMain.java
@@ -1,0 +1,7 @@
+package com.example.demo;
+
+public class setUpStreamFromSprint1ToOriginMain {
+
+    // I created this class after having checkd out to sprint1 and set the upstream to origin/master with this command:
+    // git branch -u origin/main
+}


### PR DESCRIPTION
Testing first pull request. 
Steps taken so far:
1. Created sprint1 branch from master.
2. Set upstream of sprint1 to master with: git branch -u origin/main
3. Created a class, committed and pushed.

"fatal: The upstream branch of your current branch does not match
the name of your current branch."

Command options given:

A) 
To push to the upstream branch on the remote, use
    git push origin HEAD:main
B)
To push to the branch of the same name on the remote, use
    git push origin HEAD

Chose to push to sprint1 (B) and as expected it pushed to sprint1. 
Q: Is the upstream now set to sprint1?

Output from terminal:  
   * [new branch]      HEAD -> sprint1

git branch -a:
* sprint1
  remotes/origin/HEAD -> origin/main
  remotes/origin/main
  remotes/origin/sprint1

git status - told me to push due to master being 1 commit behind. 
git push told me to choose again.

Will see what happens after I finish this pull request, which I'm guessing should merge the sprint1 into main and therefore be up to date. 


